### PR TITLE
fix: fixing crashing when /remove_service used wrong

### DIFF
--- a/burgerbot.py
+++ b/burgerbot.py
@@ -147,13 +147,16 @@ class Bot:
 
   def __remove_service(self, update: Update, _: CallbackContext) -> None:
     logging.info(f'removing service {update.message}')
-    service_id = int(update.message.text.split(' ')[1])
-    for u in self.users:
-      if u.chat_id == update.message.chat_id:
-        u.services.remove(int(service_id))
-        self.__persist_chats()
-        break
-    update.message.reply_text("Service removed")
+    try:
+      service_id = int(update.message.text.split(' ')[1])
+      for u in self.users:
+        if u.chat_id == update.message.chat_id:
+          u.services.remove(int(service_id))
+          self.__persist_chats()
+          break
+      update.message.reply_text("Service removed")
+    except IndexError:
+      update.message.reply_text("Wrong usage. Please type '/remove_service 123456'")
 
   def __poll(self) -> None:
     self.updater.start_polling()


### PR DESCRIPTION
seems like people are trying to turn off bot with `/remove_service` which actually causes it to crash