### PR TITLE
burgerbot.py: Add support for a new service

### DIFF
--- a/burgerbot.py
+++ b/burgerbot.py
@@ -30,6 +30,7 @@ service_map = {
     327537: 'Fahrerlaubnis - Umschreibung einer ausländischen',
     324280: 'Niederlassungserlaubnis oder Erlaubnis',
     318998: 'Einbürgerung - Verleihung der deutschen Staatsangehörigkeit beantragen',
+    326798: 'Blaue Karte EU auf einen neuen Pass übertragen',
 }
 
 @dataclass


### PR DESCRIPTION
Hey! First of all, Many Thanks for this tool.

`/add_service` for the service in the PR service did not really work for me in the bot. I have assumed there's an issue with that and created this PR. 