### PR TITLE
retry on connection error

### DIFF
--- a/burgerbot.py
+++ b/burgerbot.py
@@ -4,7 +4,6 @@ import json
 import threading
 import logging
 import sys
-import queue
 from dataclasses import dataclass, asdict
 from typing import List
 from datetime import datetime 

--- a/parser.py
+++ b/parser.py
@@ -1,7 +1,7 @@
 import time
 import logging
 from dataclasses import dataclass
-from typing import List 
+from typing import List
 from re import S
 
 import requests
@@ -27,9 +27,14 @@ class Parser:
     self.parse()
 
   def __get_url(self, url) -> requests.Response:
-    if self.proxy_on:
-      return requests.get(url, proxies={'https': 'socks5://127.0.0.1:9050'})
-    return requests.get(url)
+    try:
+      if self.proxy_on:
+        return requests.get(url, proxies={'https': 'socks5://127.0.0.1:9050'})
+      return requests.get(url)
+    except ConnectionResetError as err:
+      logging.warn('received an error from the server, waiting for 1 minute before retry')
+      time.sleep(60)
+      return self.__get_url(url)
 
   def __toggle_proxy(self) -> None:
     self.proxy_on = not self.proxy_on


### PR DESCRIPTION
fixing this: which occurs from time to time
```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/root/.cache/pypoetry/virtualenvs/burgerbot-R9wiGSP8-py3.8/lib/python3.8/site-packages/urllib3/connectionpool.py", line 699, in urlopen
    httplib_response = self._make_request(
  File "/root/.cache/pypoetry/virtualenvs/burgerbot-R9wiGSP8-py3.8/lib/python3.8/site-packages/urllib3/connectionpool.py", line 445, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "/root/.cache/pypoetry/virtualenvs/burgerbot-R9wiGSP8-py3.8/lib/python3.8/site-packages/urllib3/connectionpool.py", line 440, in _make_request
    httplib_response = conn.getresponse()
  File "/usr/lib/python3.8/http/client.py", line 1348, in getresponse
    response.begin()
  File "/usr/lib/python3.8/http/client.py", line 316, in begin
    version, status, reason = self._read_status()
  File "/usr/lib/python3.8/http/client.py", line 277, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/lib/python3.8/socket.py", line 669, in readinto
    return self._sock.recv_into(b)
  File "/usr/lib/python3.8/ssl.py", line 1241, in recv_into
    return self.read(nbytes, buffer)
  File "/usr/lib/python3.8/ssl.py", line 1099, in read
    return self._sslobj.read(len, buffer)
ConnectionResetError: [Errno 104] Connection reset by peer
```