### PR TITLE
feat: add driver's license exchange service

### DIFF
--- a/burgerbot.py
+++ b/burgerbot.py
@@ -37,6 +37,7 @@ service_map = {
     120914: 'Zulassung eines Fahrzeuges mit auswärtigem Kennzeichen mit Halterwechsel',
     121627: 'Fahrerlaubnis - Ersterteilung beantragen',
     120335: 'Abmeldung einer Wohnung',
+    121616: 'Führerschein - Kartenführerschein umtauschen',
 }
 
 @dataclass


### PR DESCRIPTION
Adds "Führerschein - Kartenführerschein umtauschen".

https://service.berlin.de/dienstleistung/121616/